### PR TITLE
fix(kube): kyverno's mutation on longhorn to support nixos is now mandatory

### DIFF
--- a/kube/apps/longhorn/longhorn.clusterpolicy.yaml
+++ b/kube/apps/longhorn/longhorn.clusterpolicy.yaml
@@ -20,6 +20,7 @@ metadata:
       deployments such that the PATH is explicitly set to support
       NixOS based systems.
 spec:
+  failurePolicy: Fail
   rules:
     - name: add-env-vars
       match:


### PR DESCRIPTION
closes #102