### PR TITLE
fix(kube/mailu): dovecot requires root permission with crio

### DIFF
--- a/kube/apps/mailu/mailu-hr.yaml
+++ b/kube/apps/mailu/mailu-hr.yaml
@@ -200,6 +200,7 @@ spec:
 
     dovecot:
       # on crio, we need to be root to have the SYS_CHROOT capability, and this is required by dovecot to run properly
+      # https://github.com/Mailu/Mailu/issues/1714
       containerSecurityContext:
         capabilities:
           add:


### PR DESCRIPTION
closes #345