### PR TITLE
Revert "feat(deps)!: Update Helm release traefik ( 39.0.9 ➔ 40.2.0 )"

### DIFF
--- a/kube/apps/traefik/traefik.hr.yaml
+++ b/kube/apps/traefik/traefik.hr.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: traefik
-      version: 40.2.0
+      version: 39.0.9
       sourceRef:
         kind: HelmRepository
         name: traefik


### PR DESCRIPTION
Reverts becloudless/becloudless#544
look like ssh over tls is broken 