### PR TITLE
Revert "fix(nixos): use CEF version from unstable for jellyfin-desktop"

### DIFF
--- a/nixos/packages/jellyfin-desktop/default.nix
+++ b/nixos/packages/jellyfin-desktop/default.nix
@@ -19,8 +19,6 @@
   libxcb,
 }:
 let
-  unstable = inputs.nixpkgs-unstable.legacyPackages.${pkgs.stdenv.hostPlatform.system};
-
   mpvPrefix = symlinkJoin {
     name = "mpv-external-prefix";
     paths = [
@@ -39,8 +37,8 @@ let
     dontUnpack = true;
     installPhase = ''
       mkdir -p $out
-      cp -r ${unstable.cef-binary}/Release/* $out/
-      cp -r ${unstable.cef-binary}/Resources/* $out/
+      cp -r ${pkgs.cef-binary}/Release/* $out/
+      cp -r ${pkgs.cef-binary}/Resources/* $out/
     '';
   });
 in

--- a/nixos/test.sh
+++ b/nixos/test.sh
@@ -134,7 +134,6 @@ $BCL_BIN -C "$DIR/tests/basic" nixos prepare
 
 ###
 validate-test-tv() {
-	sleep 10
 	ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ../secrets/ed25519 -p 10022 toto@127.0.0.1 sudo cat /home/tv/.config/jellyfin-desktop/start-jellyfin.log
 	ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ../secrets/ed25519 -p 10022 toto@127.0.0.1 pidof jellyfin-desktop
 }


### PR DESCRIPTION
Reverts becloudless/becloudless#613